### PR TITLE
[Fix]사진선택 영역 및 하단 텍스트 로고 반투명 제거

### DIFF
--- a/components/common/SortableItem.tsx
+++ b/components/common/SortableItem.tsx
@@ -51,7 +51,7 @@ export default function SortableItem({
       <div
         onClick={handleClick}
         className={`
-          relative w-full overflow-hidden rounded-sm bg-slate-500/90
+          relative w-full overflow-hidden rounded-sm bg-slate-500
           flex items-center justify-center
           transition-transform duration-150 ease-out
           ${isDragging && !disabled ? 'scale-120 shadow-lg' : 'scale-100 shadow-none'}
@@ -61,7 +61,7 @@ export default function SortableItem({
         {image ? (
           <img src={image} className="h-full w-full object-cover pointer-events-none" />
         ) : (
-          <span className="text-xs text-sky-100/80 pointer-events-none">클릭해서 사진 선택</span>
+          <span className="text-xs text-sky-100 pointer-events-none">클릭해서 사진 선택</span>
         )}
       </div>
 


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

사진선택 영역 및 하단 텍스트 로고 반투명 제거

## 📋 작업 내용

사진선택 영역 및 하단 텍스트 로고 반투명 제거

## 🔧 변경 사항

사진선택 영역 및 하단 텍스트 로고 반투명 제거

## 📸 스크린샷 (선택 사항)

<img width="518" height="889" alt="image" src="https://github.com/user-attachments/assets/e8c5a51d-49b7-4920-9247-1e48fa53ebe3" />

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
