### PR TITLE
[Design] Contact 페이지 기본 퍼블리싱

### DIFF
--- a/app/contact/ContactPageContent.tsx
+++ b/app/contact/ContactPageContent.tsx
@@ -1,0 +1,103 @@
+import Link from 'next/link';
+import { EnvelopeIcon } from '@heroicons/react/24/outline';
+import { UserIcon } from '@heroicons/react/24/outline';
+
+export default function ContactPageContent() {
+  return (
+    <div className="flex flex-col gap-8 items-center justify-center py-10">
+      <h1 className="text-3xl font-bold">Time Film</h1>
+
+      <div className="flex flex-wrap gap-6 justify-center max-w-4xl">
+        <div className="flex flex-col gap-4 p-6 border rounded-xl shadow-lg w-80 bg-white">
+          <div className="flex items-center gap-4">
+            <div>
+              <h2 className="text-xl font-bold">이윤환</h2>
+
+              <div className="flex items-center">
+                <UserIcon className="h-4 w-4 inline-block mr-1 text-gray-600" />
+                <p className="text-sm text-gray-600">Frontend Developer</p>
+              </div>
+
+              <div className="flex items-center">
+                <EnvelopeIcon className="h-4 w-4 inline-block mr-1 text-gray-600" />
+                <p className="text-sm text-gray-600">cyzhqly@gmail.com</p>
+              </div>
+            </div>
+          </div>
+          <p className="text-sm text-gray-700"></p>
+          <div className="flex gap-3">
+            <Link
+              href="https://github.com/unanbb"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-blue-500 hover:underline text-sm"
+            >
+              GitHub
+            </Link>
+            <Link
+              href="https://velog.io/@unanakadev/posts"
+              className="text-blue-500 hover:underline text-sm"
+            >
+              Blog
+            </Link>
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-4 p-6 border rounded-xl shadow-lg w-80 bg-white">
+          <div className="flex items-center gap-4">
+            <div>
+              <h2 className="text-xl font-bold">손성오</h2>
+
+              <div className="flex items-center">
+                <UserIcon className="h-4 w-4 inline-block mr-1 text-gray-600" />
+                <p className="text-sm text-gray-600">Frontend Developer</p>
+              </div>
+
+              <div className="flex items-center">
+                <EnvelopeIcon className="h-4 w-4 inline-block mr-1 text-gray-600" />
+                <p className="text-sm text-gray-600">thstjddh8891@gmail.com</p>
+              </div>
+            </div>
+          </div>
+          <p className="text-sm text-gray-700"></p>
+          <div className="flex gap-3">
+            <Link
+              href="https://github.com/Sonseongoh"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-blue-500 hover:underline text-sm"
+            >
+              GitHub
+            </Link>
+            <Link
+              href="https://velog.io/@sonson/posts"
+              className="text-blue-500 hover:underline text-sm"
+            >
+              Blog
+            </Link>
+          </div>
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-4 p-6 border rounded-xl shadow-lg max-w-2xl w-full bg-white">
+        <h2 className="text-xl font-bold">Project Links</h2>
+        <div className="flex flex-col gap-3">
+          <Link
+            href="https://github.com/Time-Film/Time-Film"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex items-center gap-2 text-blue-500 hover:underline"
+          >
+            <span className="font-medium">GitHub Repository</span>
+            <span className="text-sm text-gray-500">→</span>
+          </Link>
+
+          <Link href="/report" className="flex items-center gap-2 text-blue-500 hover:underline">
+            <span className="font-medium">Contact Us</span>
+            <span className="text-sm text-gray-500">→</span>
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -1,0 +1,5 @@
+import ContactPageContent from '@/app/contact/ContactPageContent';
+
+export default function ContactPage() {
+  return <ContactPageContent />;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@dnd-kit/modifiers": "^9.0.0",
         "@dnd-kit/sortable": "^10.0.0",
         "@emailjs/browser": "^4.4.1",
+        "@heroicons/react": "^2.2.0",
         "date-fns": "^4.1.0",
         "html-to-image": "^1.11.13",
         "lefthook": "^2.0.4",
@@ -1040,6 +1041,15 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@heroicons/react": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@heroicons/react/-/react-2.2.0.tgz",
+      "integrity": "sha512-LMcepvRaS9LYHJGsF0zzmgKCUim/X3N/DQKc4jepAXJ7l8QxJ1PmxJzqplF2Z3FE4PqBAIGyJAQ/w4B5dsqbtQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">= 16 || ^19.0.0-rc"
       }
     },
     "node_modules/@humanfs/core": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@dnd-kit/modifiers": "^9.0.0",
     "@dnd-kit/sortable": "^10.0.0",
     "@emailjs/browser": "^4.4.1",
+    "@heroicons/react": "^2.2.0",
     "date-fns": "^4.1.0",
     "html-to-image": "^1.11.13",
     "lefthook": "^2.0.4",


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

**[작업 내용을 간략히 적어주세요]**

## 📋 작업 내용

Contact 페이지 퍼블리싱 후 라우팅 주소 연결 했습니다.
아이콘 라이브러리 설치했습니다.

## 🔧 변경 사항

- Contact 폴더 및 `page.tsx` 생성
- 아이콘을 위해 Tailwind 사에서 만든 `heroicons` 라이브러리 설치 및 사용

## 📸 스크린샷 (선택 사항)
<img width="1168" height="1286" alt="image" src="https://github.com/user-attachments/assets/0a10dd9c-3866-424d-9e0e-183db96dabca" />



## 📄 기타
Github/Blog 버튼: 각각의 Github/Blog 주소로 이동 (새 창)
Github repository 버튼: 프로젝트 깃허브 주소로 이동 (새창)
Contact Us 버튼: 문의하기 페이지로 이동 (현재 창)
