### PR TITLE
[Fix] 레이아웃별 필요 이미지 수 검증 로직 수정

### DIFF
--- a/app/frame/view/ViewPageContent.tsx
+++ b/app/frame/view/ViewPageContent.tsx
@@ -7,11 +7,16 @@ import { GA_CTA_EVENTS } from '@/constants/ga';
 import { sendGAEvent } from '@next/third-parties/google';
 import { useFrameStore } from '@/stores/useFrameStore';
 import { Toast } from '@/components/common/Toast';
+import { LAYOUT_TO_COUNT } from '@/constants/layout';
 
 export default function ViewPageContent() {
   const router = useRouter();
+  const layout = useFrameStore(s => s.layout);
   const images = useFrameStore(s => s.images);
-  const unUploadedImages = images.filter(img => img === null);
+
+  const requiredImageCount = LAYOUT_TO_COUNT[layout];
+  const visibleImages = images.slice(0, requiredImageCount);
+  const isImageFull = visibleImages.every(img => img !== null);
 
   const handleBack = () => {
     sendGAEvent('event', GA_CTA_EVENTS.clickReselectFrame, {
@@ -28,7 +33,7 @@ export default function ViewPageContent() {
       cta: 'confirm',
     });
 
-    if (unUploadedImages.length > 0) {
+    if (!isImageFull) {
       Toast.error('모든 사진을 업로드 해주세요. 🐳');
       return;
     }

--- a/components/common/PhotoFrame.tsx
+++ b/components/common/PhotoFrame.tsx
@@ -16,19 +16,13 @@ import {
   rectSortingStrategy,
 } from '@dnd-kit/sortable';
 import { useState } from 'react';
-import { useFrameStore, Layout } from '@/stores/useFrameStore';
+import { useFrameStore } from '@/stores/useFrameStore';
 import SortableItem from '@/components/common/SortableItem';
 import { COLORS } from '@/types/colors';
 import useSkinStore from '@/stores/useSkinStore';
 import { SKINS } from '@/types/skins';
 import { convertHeicToJpeg } from '@/utils/convertHeic';
-
-const LAYOUT_TO_COUNT: Record<Layout, number> = {
-  '1x2': 2,
-  '1x3': 3,
-  '1x4': 4,
-  '2x2': 4,
-};
+import { LAYOUT_TO_COUNT } from '@/constants/layout';
 
 interface PhotoFrameProps {
   enableDnd?: boolean;

--- a/constants/layout.ts
+++ b/constants/layout.ts
@@ -1,0 +1,8 @@
+import { Layout } from '@/stores/useFrameStore';
+
+export const LAYOUT_TO_COUNT: Record<Layout, number> = {
+  '1x2': 2,
+  '1x3': 3,
+  '1x4': 4,
+  '2x2': 4,
+};

--- a/stores/useFrameStore.ts
+++ b/stores/useFrameStore.ts
@@ -25,13 +25,7 @@ const initialState = {
 
 export const useFrameStore = create<FrameState>(set => ({
   ...initialState,
-  setLayout: layout => {
-    const imageCount = layout.split('x').reduce((a, b) => +a * +b, 1);
-    set({
-      layout,
-      images: Array(imageCount).fill(null),
-    });
-  },
+  setLayout: layout => set({ layout }),
 
   setImage: (index, url) =>
     set(state => {


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

**[작업 내용을 간략히 적어주세요]**

## 📋 작업 내용

기존 [37a4a3e](https://github.com/PHOTOWHALE/PHOTOWHALE/pull/100/commits/37a4a3eeb3a3e8181bfcffb9ea4e0324cce73696) 방식이 가진 전체 이미지 수 검증 로직이 가진 오류를 수정했습니다.

- 레이아웃 재 선택 시 store의 `layout`만 바뀔 뿐 `images`는 변경되지 않아 이미지 수 검증에 오류 발생
- 이는 레이아웃 변경 시에도 등록한 이미지가 손실되지 않도록 의도한 설계.
- 이 의도를 살리도록 검증 로직을 수정

`view` 페이지에서 `layout`과 `images`를 둘다 구독하여, 현재 **`layout`이 필요한 이미지 수**와 **images 배열을 0번 부터 자른 배열**의 `length`를 비교하는 방식으로 진행 

## 🔧 변경 사항
- `layout.ts` 생성
- `ViewPageContent.tsx`에 검증 로직 수정


## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부할 수 있습니다.

## 📄 기타

로컬에서 동작 잘되는거 확인했고, 프리뷰 서버 같이 테스트 부탁드립니다!
