### PR TITLE
[Fix] Header 컴포넌트에서 빈 공간을 눌러도 리셋 함수가 실행되는 오류 수정

### DIFF
--- a/components/common/Header.tsx
+++ b/components/common/Header.tsx
@@ -7,9 +7,16 @@ import resetFrameStores from '@/utils/resetFrameStores';
 export default function Header() {
   const pathname = usePathname();
 
+  const handleClick = (e: React.MouseEvent<HTMLUListElement>) => {
+    const target = e.target as HTMLElement;
+    if (target.closest('li')) {
+      resetFrameStores();
+    }
+  };
+
   return (
     <ul
-      onClick={resetFrameStores}
+      onClick={handleClick}
       className="flex items-center justify-around h-12 my-4 px-4 w-[70%] gap-4 bg-[#FFFDF8] font-semibold rounded-full shadow-sm text-sm z-20"
     >
       <li>


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

**[작업 내용을 간략히 적어주세요]**

## 📋 작업 내용

Header 컴포넌트에서 빈 공간을 눌러도 리셋 함수가 실행되는 오류 수정

## 🔧 변경 사항

`closest()` 메소드를 이용하여 클릭된 요소가 `li` 태그일 때만 `resetFrameStore()`이 실행되도록 수정

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부할 수 있습니다.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
