### PR TITLE
[Feat] 업로드 이미지 파일 용량제한

### DIFF
--- a/components/common/SortableItem.tsx
+++ b/components/common/SortableItem.tsx
@@ -84,7 +84,7 @@ export default function SortableItem({
         ) : (
           <div className="flex flex-col items-center gap-1 text-white/80">
             <ImagePlus className="w-6 h-6" />
-            <span className="text-[10px] opacity-70">5MB 이하 파일</span>
+            <span className="text-[10px] opacity-70">7MB 이하 파일</span>
           </div>
         )}
         {!disableImageChange && (

--- a/hooks/useImageUpload.ts
+++ b/hooks/useImageUpload.ts
@@ -38,7 +38,7 @@ export function useImageUpload({
     if (!file) return;
 
     if (file.size > MAX_FILE_SIZE) {
-      Toast.error('이미지 용량은 5MB 이하만 업로드할 수 있습니다.');
+      Toast.error('이미지 용량은 7MB 이하만 업로드할 수 있습니다.');
       input.value = ''; // 동일 파일 재선택 가능
       return;
     }


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

업로드 이미지 파일 용량제한

## 📋 작업 내용

파일용량 5mb 이하 만 가능하며 초과할시 토스트 알림 , 5mb이하 파일 만 가능하다는 텍스트 문구 추가

## 🔧 변경 사항

파일용량 5mb 이하 만 가능하며 초과할시 토스트 알림이 나타납니다
이미지 업로드 아이콘 밑에 5mb이하 파일 만 가능하다는 텍스트 문구 추가하였습니다

## 📸 스크린샷 (선택 사항)

<img width="292" height="572" alt="image" src="https://github.com/user-attachments/assets/5515f78a-12d6-4d51-bfac-467af9f07f40" />

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
