### PR TITLE
[Feat] 결과물 공유 시 링크 추가 및 title 제거

### DIFF
--- a/app/frame/edit/EditPageContent.tsx
+++ b/app/frame/edit/EditPageContent.tsx
@@ -121,8 +121,7 @@ export default function EditPageContent() {
 
       await navigator.share({
         files: [file],
-        title: 'Photo Whale',
-        text: '내가 만든 프레임 사진이야 🐳',
+        text: '내가 만든 프레임 사진이야 🐳\nhttps://photowhale.vercel.app',
       });
     } catch (err) {
       console.log('share canceled or failed', err);


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

**[작업 내용을 간략히 적어주세요]**

## 📋 작업 내용

결과물 공유 시 링크 추가 및 title 제거

## 🔧 변경 사항

- `Safari` 환경에서만 정상 출력되는 `text` 필드에 서비스 url을 추가하여 이미지를 공유받은 사용자가 바로 서비스를 즐길 수 있도록 UX를 개선했습니다.
- `title` 필드는 `file` 필드가 존재하면 기본적으로 출력이 되지않습니다. 공유에 실패하더라도 `try/catch`에러처리로 인해 `file` 필드가 비어있는 경우는 존재하지 않으므로 `title` 필드는 사용되지 못해 삭제했습니다.

❕ `Android` / `Chrome` 등에서는 브라우저 동작 방식 차이로 인해 공유 시 `text`와 `url`필드를 인식하지 못하여 `file` 필드 내용만 공유됩니다.

## 📸 스크린샷 (선택 사항)

(아이폰 환경에서 확인 필요)

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
