### PR TITLE
[Fix] 사진 저장시 저장된 이미지에 dnd 아이콘 안보이게 수정

### DIFF
--- a/components/common/SortableItem.tsx
+++ b/components/common/SortableItem.tsx
@@ -69,7 +69,7 @@ export default function SortableItem({
       >
         {!disabled && (
           <div className="absolute top-1 right-1 opacity-60 pointer-events-none">
-            <GripVertical size={14} />
+            <GripVertical size={14} data-export-ignore />
           </div>
         )}
         {id === totalCount - 1 && (

--- a/utils/exportImage.ts
+++ b/utils/exportImage.ts
@@ -9,6 +9,10 @@ interface ExportPngOptions {
 
 const isIOS = typeof navigator !== 'undefined' && /iP(hone|ad|od)/i.test(navigator.userAgent);
 
+const exportFilter = (domNode: HTMLElement) => {
+  return !domNode.hasAttribute?.('data-export-ignore');
+};
+
 async function buildBlob(
   element: HTMLElement,
   pixelRatio: number,
@@ -29,6 +33,7 @@ async function buildBlob(
     const blob = await toBlob(element, {
       cacheBust: true,
       pixelRatio,
+      filter: exportFilter,
     });
 
     if (blob) {
@@ -64,6 +69,7 @@ export async function exportImage(
     : await toBlob(node, {
         cacheBust: true,
         pixelRatio,
+        filter: exportFilter,
       });
 
   if (!blob) {


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

사진 저장시 저장된 이미지에 dnd 아이콘 안보이게 수정

## 📋 작업 내용

사진 저장시 저장된 이미지에 dnd 아이콘 안보이게 수정

## 🔧 변경 사항

저장된 사진에는 DND 아이콘이 보이지 않습니다

## 📸 스크린샷 (선택 사항)

저장된 이미지)
<img width="344" height="752" alt="image" src="https://github.com/user-attachments/assets/a02836f2-0c7c-4036-9aa0-db8d8c92c4f0" />

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
