### PR TITLE
[Feat]dnd대상이 영역 밖으로 벗어나지 않도록 제한

### DIFF
--- a/components/common/PhotoFrame.tsx
+++ b/components/common/PhotoFrame.tsx
@@ -21,6 +21,7 @@ import {
   SortableContext,
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable';
+import { restrictToParentElement } from '@dnd-kit/modifiers';
 
 interface PhotoFrameProps {
   enableDnd?: boolean;
@@ -93,7 +94,12 @@ export default function PhotoFrame({
             </div>
           </div>
         )}
-        <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+        <DndContext
+          sensors={sensors}
+          collisionDetection={closestCenter}
+          onDragEnd={handleDragEnd}
+          modifiers={[restrictToParentElement]}
+        >
           <SortableContext
             items={Array.from({ length: visibleCount }, (_, i) => i)}
             strategy={isGrid ? rectSortingStrategy : verticalListSortingStrategy}

--- a/components/common/SortableItem.tsx
+++ b/components/common/SortableItem.tsx
@@ -63,7 +63,7 @@ export default function SortableItem({
           relative w-full overflow-hidden rounded-sm bg-slate-500
           flex items-center justify-center
           transition-transform duration-150 ease-out
-          ${isDragging && !disabled ? 'scale-120 shadow-lg' : 'scale-100 shadow-none'}
+          ${isDragging && !disabled ? 'scale-115 shadow-lg' : 'scale-100 shadow-none'}
           ${isGrid ? 'aspect-4/5' : 'aspect-3/2'}
         `}
       >


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

dnd대상이 영역 밖으로 벗어나지 않도록 제한

## 📋 작업 내용
dnd대상이 영역 밖으로 벗어나지 않도록 제한하였습니다

## 🔧 변경 사항

dnd대상이 영역 밖으로 벗어나지 않도록 제한
그에 맞춰 sortableItem을 드래그할때 120%로 커지던것을 115%로 미세조정

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부할 수 있습니다.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
