### PR TITLE
[Refactor]GA이벤트 추상화

### DIFF
--- a/app/(home)/HomePageContent.tsx
+++ b/app/(home)/HomePageContent.tsx
@@ -2,13 +2,13 @@
 
 import Button from '@/components/common/Button';
 import Link from 'next/link';
-import { sendGAEvent } from '@next/third-parties/google';
 import { GA_CTA_EVENTS } from '@/constants/ga';
 import InfiniteRolling from '@/components/common/homePage/InfiniteRolling';
+import { analytics } from '@/lib/ga/analytics';
 
 export default function HomePageContent() {
   const handleStartClick = () => {
-    sendGAEvent('event', GA_CTA_EVENTS.clickStart, {
+    analytics.track(GA_CTA_EVENTS.clickStart, {
       page: 'home',
     });
   };

--- a/app/contact/ContactPageContent.tsx
+++ b/app/contact/ContactPageContent.tsx
@@ -5,9 +5,9 @@ import Input from '@/components/common/Input';
 import TextArea from '@/components/common/TextArea';
 import emailjs from '@emailjs/browser';
 import { useRef } from 'react';
-import { sendGAEvent } from '@next/third-parties/google';
 import { GA_CTA_EVENTS } from '@/constants/ga';
 import { Toast } from '@/components/common/Toast';
+import { analytics } from '@/lib/ga/analytics';
 
 export default function ContactPageContent() {
   const form = useRef<HTMLFormElement>(null);
@@ -15,7 +15,7 @@ export default function ContactPageContent() {
   const sendEmail = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
-    sendGAEvent('event', GA_CTA_EVENTS.clickContactSubmit, {
+    analytics.track(GA_CTA_EVENTS.clickContactSubmit, {
       page: 'contact',
     });
 
@@ -27,14 +27,14 @@ export default function ContactPageContent() {
         () => {
           Toast.success('문의가 성공적으로 전송되었어요! 🐳');
 
-          sendGAEvent('event', GA_CTA_EVENTS.submitContactSuccess, {
+          analytics.track(GA_CTA_EVENTS.submitContactSuccess, {
             page: 'contact',
           });
 
           form.current?.reset();
         },
         (error: { text: string }) => {
-          sendGAEvent('event', GA_CTA_EVENTS.submitContactFail, {
+          analytics.track(GA_CTA_EVENTS.submitContactFail, {
             page: 'contact',
             error_message: error.text,
           });

--- a/app/frame/edit/EditPageContent.tsx
+++ b/app/frame/edit/EditPageContent.tsx
@@ -13,7 +13,6 @@ import Image from 'next/image';
 import { exportImage } from '@/utils/exportImage';
 import Button from '@/components/common/Button';
 import { useRouter } from 'next/navigation';
-import { sendGAEvent } from '@next/third-parties/google';
 import { GA_CTA_EVENTS } from '@/constants/ga';
 import resetFrameStores from '@/utils/resetFrameStores';
 import { useCanShare } from '@/hooks/useCanShare';
@@ -24,6 +23,7 @@ import { useModal } from '@/hooks/useModal';
 import { ArrowPathIcon } from '@heroicons/react/24/outline';
 import { FILTERS } from '@/types/filter';
 import useFilterStore from '@/stores/useFilterStore';
+import { analytics } from '@/lib/ga/analytics';
 
 type BtnClickEventType = 'skin' | 'color' | 'filter';
 
@@ -88,14 +88,14 @@ export default function EditPageContent() {
   const filterInitialSlide = FILTERS.findIndex(f => f.id === filter);
 
   const handleRestartClick = () => {
-    sendGAEvent('event', GA_CTA_EVENTS.clickReStart, {
+    analytics.track(GA_CTA_EVENTS.clickReStart, {
       page: 'edit',
     });
 
     close();
     router.push('/frame/select');
     resetFrameStores();
-    sendGAEvent(GA_CTA_EVENTS.clickReStart);
+    analytics.track(GA_CTA_EVENTS.clickReStart);
   };
 
   const handleSaveClick = async () => {
@@ -104,7 +104,7 @@ export default function EditPageContent() {
 
     setIsSaving(true);
 
-    sendGAEvent('event', GA_CTA_EVENTS.clickDownloadPhotoSubmit, {
+    analytics.track(GA_CTA_EVENTS.clickDownloadPhotoSubmit, {
       page: 'edit',
       frame_color: bgColor,
       skin,
@@ -113,7 +113,7 @@ export default function EditPageContent() {
     try {
       await exportImage(node, { pixelRatio: 2 });
 
-      sendGAEvent('event', GA_CTA_EVENTS.clickDownloadPhotoSuccess, {
+      analytics.track(GA_CTA_EVENTS.clickDownloadPhotoSuccess, {
         page: 'edit',
         frame_color: bgColor,
         skin,
@@ -121,7 +121,7 @@ export default function EditPageContent() {
 
       Toast.success('이미지가 저장되었어요! 🐳');
     } catch (err) {
-      sendGAEvent('event', GA_CTA_EVENTS.clickDownloadPhotoFail, {
+      analytics.track(GA_CTA_EVENTS.clickDownloadPhotoFail, {
         page: 'edit',
         reason: err instanceof Error ? err.message : 'unknown',
       });
@@ -137,7 +137,7 @@ export default function EditPageContent() {
     const node = captureRef.current;
     if (!node) return;
 
-    sendGAEvent('event', GA_CTA_EVENTS.clickSharePhoto, {
+    analytics.track(GA_CTA_EVENTS.clickSharePhoto, {
       page: 'edit',
       frame_color: bgColor,
       skin,

--- a/app/frame/view/ViewPageContent.tsx
+++ b/app/frame/view/ViewPageContent.tsx
@@ -6,10 +6,10 @@ import { Toast } from '@/components/common/Toast';
 import { GA_CTA_EVENTS } from '@/constants/ga';
 import { LAYOUT_TO_COUNT } from '@/constants/layout';
 import { useFrameStore } from '@/stores/useFrameStore';
-import { sendGAEvent } from '@next/third-parties/google';
 import { useRouter } from 'next/navigation';
 import Modal from '@/components/common/Modal';
 import { useModal } from '@/hooks/useModal';
+import { analytics } from '@/lib/ga/analytics';
 
 export default function ViewPageContent() {
   const { isOpen, setIsOpen, open, close } = useModal();
@@ -23,7 +23,7 @@ export default function ViewPageContent() {
   const isImageFull = visibleImages.every(img => img !== null);
 
   const handleBack = () => {
-    sendGAEvent('event', GA_CTA_EVENTS.clickReselectFrame, {
+    analytics.track(GA_CTA_EVENTS.clickReselectFrame, {
       page: 'view',
       cta: 'reselect',
     });
@@ -38,7 +38,7 @@ export default function ViewPageContent() {
   };
 
   const handleConfirm = () => {
-    sendGAEvent('event', GA_CTA_EVENTS.clickFinishSelectPhoto, {
+    analytics.track(GA_CTA_EVENTS.clickFinishSelectPhoto, {
       page: 'view',
       cta: 'confirm',
     });

--- a/components/common/selectPage/FrameLayoutGrid.tsx
+++ b/components/common/selectPage/FrameLayoutGrid.tsx
@@ -4,8 +4,8 @@ import { useRouter } from 'next/navigation';
 import { useFrameStore, Layout } from '@/stores/useFrameStore';
 import FrameLayoutCard from './FrameLayoutCard';
 import FrameLayoutPreview from './FrameLayoutPreview';
-import { sendGAEvent } from '@next/third-parties/google';
 import { GA_CTA_EVENTS } from '@/constants/ga';
+import { analytics } from '@/lib/ga/analytics';
 
 const LAYOUTS: { id: Layout; title: string; sub: string }[] = [
   { id: '1x4', title: 'Layout A', sub: '4 Pose' },
@@ -20,7 +20,7 @@ export default function FrameLayoutGrid() {
   const setLayout = useFrameStore(state => state.setLayout);
 
   const handlePick = (next: Layout) => {
-    sendGAEvent('event', GA_CTA_EVENTS.clickSelectFrame, {
+    analytics.track(GA_CTA_EVENTS.clickSelectFrame, {
       page: 'select',
       frame_layout: next,
     });

--- a/lib/ga/analytics.ts
+++ b/lib/ga/analytics.ts
@@ -1,0 +1,23 @@
+import { sendGAEvent } from '@next/third-parties/google';
+
+type EventParams = Record<string, unknown>;
+
+export interface Analytics {
+  track: (event: string, params?: EventParams) => void;
+}
+
+export const analytics: Analytics = {
+  track(event, params) {
+    try {
+      if (params) {
+        sendGAEvent('event', event, params);
+      } else {
+        sendGAEvent('event', event);
+      }
+    } catch (error) {
+      if (process.env.NODE_ENV !== 'production') {
+        console.error('GA track failed:', error);
+      }
+    }
+  },
+};


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

GA 이벤트 호출부를 analytics.track 추상화 레이어로 리팩터링했습니다.

## 📋 작업 내용

기존에는 각 페이지/컴포넌트에서 sendGAEvent를 직접 호출하고 있었는데, 이를 공통 추상화 레이어를 통해 호출하도록 변경했습니다.
이번 작업으로 이벤트 전송 구현이 한 곳으로 모여, 향후 분석 도구 변경이나 로깅 정책 추가 시 수정 범위를 줄일 수 있게 했습니다.

## 🔧 변경 사항

1)lib/ga/analytics.ts 추가
내부에서 기존 sendGAEvent를 호출하도록 래핑

2)기존 sendGAEvent 직접 호출부를 analytics.track으로 일괄 변경
app/(home)/HomePageContent.tsx
components/common/selectPage/FrameLayoutGrid.tsx
app/frame/view/ViewPageContent.tsx
app/frame/edit/EditPageContent.tsx
app/contact/ContactPageContent.tsx

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부할 수 있습니다.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
